### PR TITLE
Jwscook/timing colours

### DIFF
--- a/bash_command_timer.sh
+++ b/bash_command_timer.sh
@@ -35,17 +35,18 @@
 #     BCT_ENABLE=1
 BCT_ENABLE=1
 
-# The color of the output.
+# The color of the output for successful and failed commands respectively.
 #
-# This should be a color string  usable in a VT100 escape sequence (see
+# They should be a color string usable in a VT100 escape sequence (see
 # http://en.wikipedia.org/wiki/ANSI_escape_code#Colors), without the
 # escape sequence prefix and suffix. For example, bold red would be '1;31'.
 #
-# If empty, disable colored output. Set it to empty if your terminal does not
-# support VT100 escape sequences.
-#
 # The color of the output is set in the function BCTPreCommand
-# e.g. BCT_COLOR='34'
+#
+# If empty, disable colored output. Set them to empty if your terminal does not
+# support VT100 escape sequences.
+BCT_SUCCESS_COLOR='32'
+BCT_ERROR_COLOR='91'
 
 # The display format of the current time.
 #
@@ -111,10 +112,10 @@ function BCTPreCommand() {
   if [ $EXIT == 0 ]
   then
     # colour for exit without error
-    BCT_COLOR='36'
+    BCT_COLOR=$BCT_SUCCESS_COLOR
   else
     # colour for exit with error
-    BCT_COLOR='91'
+    BCT_COLOR=$BCT_ERROR_COLOR
   fi
   if [ -z "$BCT_AT_PROMPT" ]; then
     return

--- a/bash_command_timer.sh
+++ b/bash_command_timer.sh
@@ -43,7 +43,9 @@ BCT_ENABLE=1
 #
 # If empty, disable colored output. Set it to empty if your terminal does not
 # support VT100 escape sequences.
-BCT_COLOR='34'
+#
+# The color of the output is set in the function BCTPreCommand
+# e.g. BCT_COLOR='34'
 
 # The display format of the current time.
 #

--- a/bash_command_timer.sh
+++ b/bash_command_timer.sh
@@ -105,6 +105,15 @@ fi
 # flag is set and clear it after the first execution.
 BCT_AT_PROMPT=1
 function BCTPreCommand() {
+  local EXIT="$?"
+  if [ $EXIT == 0 ]
+  then
+    # colour for exit without error
+    BCT_COLOR='36'
+  else
+    # colour for exit with error
+    BCT_COLOR='91'
+  fi
   if [ -z "$BCT_AT_PROMPT" ]; then
     return
   fi


### PR DESCRIPTION
This changes the colours of the timing such that the timings for failed commands are in red, but otherwise the timings are in green:

![image](https://user-images.githubusercontent.com/15519866/73532155-0872d700-4414-11ea-907e-a3ef2937e513.png)
