### PR TITLE
Improve compatibility: use bash-preexec instead of manually manipulating `COMMAND_PROMPT` and `DEBUG` trap

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "bash-preexec"]
+	path = bash-preexec
+	url = https://github.com/rcaloras/bash-preexec.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "bash-preexec"]
-	path = bash-preexec
-	url = https://github.com/rcaloras/bash-preexec.git

--- a/README.md
+++ b/README.md
@@ -22,8 +22,11 @@ This script should run pretty much out of the box on modern Linux and Mac OS X
 systems. Please report any incompatibilities on
 [on GitHub](https://github.com/jichu4n/bash-command-timer/issues).
 
-Note that this script will also conflict with any other script that uses the
-DEBUG trap and `PROMPT_COMMAND`.
+Note that by default, this script will conflict with any other script that uses the
+DEBUG trap and `PROMPT_COMMAND`. However, if 
+[`bash-preexec`](https://github.com/rcaloras/bash-preexec) is detected on your 
+system, then it will be used to maintain compatibility with other scripts using
+`bash-preexec`.
 
 Installation
 ------------
@@ -61,6 +64,9 @@ you want the changes to only affect your current Bash session.
   current time will not be printed.
 * `BCT_MILLIS=1`: Whether to print timings to millisecond precision. If set to
   zero, will print timings up to seconds.
+* `BASH_PREEXEC_LOCATION='/usr/share/bash-preexec/bash-preexec.sh'`: If 
+  `bash-preexec` is installed in a non-standard location, you can set its path 
+  here
 
 Details
 -------

--- a/bash_command_timer.sh
+++ b/bash_command_timer.sh
@@ -106,6 +106,7 @@ else
 fi
 
 
+# BCTPreCommand is trapped to the DEBUG trap, manually or through bash-preexec.
 # The debug trap is invoked before the execution of each command typed by the
 # user (once for every command in a composite command) and again before the
 # execution of PROMPT_COMMAND after the user's command finishes. Thus, to be
@@ -212,13 +213,13 @@ function BCTPostCommand() {
 
 # Callbacks BCTPreCommand() and BCTPostCommand() can be tied to the `DEBUG` 
 # trap and `PROMPT_COMMAND` variable in two ways: 
-#   * Either manually, which allows the script to be self-contained be breaks 
-#     compatibility with any other script that uses this trap/variable
-#   * Either through `bash-preexec`, which allows several script to tie 
-#     callbacks to this trap/variable, but isn't self contained
+#   * Manually, which makes the script self-contained but breaks compatibility 
+#     with other scripts that use DEBUG/PROMPT_COMMAND,
+#   * Through `bash-preexec`, which allows several scripts to tie callbacks to
+#     DEBUG/PROMPT_COMMAND, but isn't self contained,
 #
-# If `bash-preexec` is found on the system, then it is used. If not available,
-# fall back onto the manual way. 
+# If `bash-preexec` is found on the system, method 1 is used. Else, we fall 
+# back to the manual way. 
 #
 function register_callbacks_with_bash_preexec() {
   source "$BASH_PREEXEC_LOCATION"
@@ -232,7 +233,7 @@ function register_callbacks_manually() {
 # Case 1: User-supplied path via BASH_PREEXEC_LOCATION
 if ! [ -z "$BASH_PREEXEC_LOCATION" ] && [ -f "$BASH_PREEXEC_LOCATION" ]; then
   register_callbacks_with_bash_preexec
-# Case 2: common installation location
+# Case 2: Common installation locations
 elif [ -f '/usr/share/bash-preexec/bash-preexec.sh' ]; then 
   BASH_PREEXEC_LOCATION='/usr/share/bash-preexec/bash-preexec.sh'
   register_callbacks_with_bash_preexec

--- a/bash_command_timer.sh
+++ b/bash_command_timer.sh
@@ -70,9 +70,6 @@ BCT_MILLIS=1
 # characters of last command's output
 BCT_WRAP=0
 
-# Path to bash-preexec
-BCT_BASH_PREEXEC=$(dirname "${BASH_SOURCE[0]}")/bash-preexec/bash-preexec.sh
-
 
 
 # IMPLEMENTATION
@@ -107,6 +104,23 @@ else
   echo 'No compatible date, gdate or perl commands found, aborting'
   exit 1
 fi
+
+
+# Source bash-preexec
+if [ -z "$BASH_PREEXEC_LOCATION" ]; then
+    # Best case: standalone install at standard location
+    BASH_PREEXEC_LOCATION=/usr/share/bash-preexec/bash-preexec.sh
+fi
+if [ ! -f "$BASH_PREEXEC_LOCATION" ]; then
+    # Fallback: bundled with bash_command_timer.sh
+    BASH_PREEXEC_LOCATION="$( dirname "${BASH_SOURCE[0]}" )/bash-preexec/bash-preexec.sh"
+fi
+if ! [ -f "$BASH_PREEXEC_LOCATION" ]; then
+    echo "Could not find bash-preexec.sh"
+    exit 1
+fi
+source "$BASH_PREEXEC_LOCATION"
+
 
 
 # The debug trap is invoked before the execution of each command typed by the
@@ -216,4 +230,4 @@ function BCTPostCommand() {
 # Register callbacks into bash-preexec
 preexec_functions+=(BCTPreCommand)
 precmd_functions+=(BCTPostCommand)
-source "$BCT_BASH_PREEXEC"
+

--- a/bash_command_timer.sh
+++ b/bash_command_timer.sh
@@ -16,12 +16,16 @@
 #                                                                             #
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 
+
+
 # A simple Bash script for printing timing information for each command line
 # executed.
 #
 # For the most up-to-date version, as well as further information and
 # installation instructions, please visit the GitHub project page at
 #     https://github.com/jichuan89/bash-command-timer
+
+
 
 # SETTINGS
 # ========
@@ -66,6 +70,10 @@ BCT_MILLIS=1
 # characters of last command's output
 BCT_WRAP=0
 
+# Path to bash-preexec
+BCT_BASH_PREEXEC=$(dirname "${BASH_SOURCE[0]}")/bash-preexec/bash-preexec.sh
+
+
 
 # IMPLEMENTATION
 # ==============
@@ -100,6 +108,7 @@ else
   exit 1
 fi
 
+
 # The debug trap is invoked before the execution of each command typed by the
 # user (once for every command in a composite command) and again before the
 # execution of PROMPT_COMMAND after the user's command finishes. Thus, to be
@@ -123,10 +132,11 @@ function BCTPreCommand() {
   unset BCT_AT_PROMPT
   BCT_COMMAND_START_TIME=$(eval $BCTTime)
 }
-trap 'BCTPreCommand' DEBUG
+
 
 # Bash will automatically set COLUMNS to the current terminal width.
 export COLUMNS
+
 
 # Flag to prevent printing out the time upon first login.
 BCT_FIRST_PROMPT=1
@@ -201,4 +211,9 @@ function BCTPostCommand() {
   # Finally, print output.
   echo -e "${output_str_colored}"
 }
-PROMPT_COMMAND='BCTPostCommand'
+
+
+# Register callbacks into bash-preexec
+preexec_functions+=(BCTPreCommand)
+precmd_functions+=(BCTPostCommand)
+source "$BCT_BASH_PREEXEC"


### PR DESCRIPTION
One may want to use `bash-command-timer` in conjunction with scripts such as [`undistract-me`](https://github.com/jml/undistract-me). But as mentioned in the README here, `bash-command-timer` is incompatible with any script that uses `$ COMMAND_PROMPT` or the `DEBUG` trap, because `bash-command-timer` manipulates these directly. 

The script [`bash-preexec`](https://github.com/rcaloras/bash-preexec/) solves this problem. It provides a way for independant scripts to hook callback functions to be executed before and after each user command. 

This Pull Requests integrates `bash-preexec` as a submodule and hooks functions `BCTPreCommand` and `BCTPostCommand` into the function arrays `preexec_functions` and `precmd_functions` provided by `bash-preexec`. This makes `bash-command-timer` compatible with other scripts that rely on `bash-preexec`, such as `undistract-me`

-----

I tested it and it works on my system. Would you consider merging this ? This would be really useful for people that want to use several scripts of that kind.

If you want to merge it in another manner (e.g. copy the file once instead of using a submodule), or want some further specific testing, let me know, I'm happy to help. (Once this is fixed & with your permission, I would also like to make arch linux package for this repo)