### PR TITLE
Preserve underscore variable ($_)

### DIFF
--- a/bash_command_timer.sh
+++ b/bash_command_timer.sh
@@ -227,8 +227,8 @@ function BCTRegisterCallbacksWithBashPreexec() {
   precmd_functions+=(BCTPostCommand)
 }
 function BCTRegisterCallbacksDirectly() {
-  trap 'BCTPreCommand' DEBUG
-  PROMPT_COMMAND='BCTPostCommand'
+  trap 'BCTPreCommand "$_"' DEBUG
+  PROMPT_COMMAND+=('BCTPostCommand')
 }
 # Case 1: User-supplied path via BASH_PREEXEC_LOCATION
 if ! [ -z "$BASH_PREEXEC_LOCATION" ] && [ -f "$BASH_PREEXEC_LOCATION" ]; then


### PR DESCRIPTION
To preserve the variable underscore (`$_`), can pass it as argument function in a trap DEBUG.
_Originally posted by @NRZCode in https://github.com/jichu4n/bash-command-timer/issues/6#issuecomment-2300823123_
The PROMPT_COMMAND variable is an array